### PR TITLE
Fix #3 and #4: Fails on Windows

### DIFF
--- a/lib/shellescape.js
+++ b/lib/shellescape.js
@@ -1,0 +1,15 @@
+'use strict';
+
+module.exports = shellescape;
+
+function shellescape(arg) {
+  if (Array.isArray(arg)) {
+    return arg.map(shellescape).join(" ");
+  } else {
+    if (/["'` \\$]/.test(arg)) {
+      return '"' + arg.replace(/(["`\\$])/g, '\\$1') + '"';
+    } else {
+      return arg;
+    }
+  }
+}

--- a/lib/tsc.js
+++ b/lib/tsc.js
@@ -4,7 +4,7 @@ var path = require('path');
 var fs = require('fs');
 var child_process = require('child_process');
 var which = require('which');
-var shellescape = require('shell-escape');
+var shellescape = require('./shellescape');
 
 module.exports.exec = exec;
 module.exports.version = version;
@@ -31,7 +31,7 @@ function exec(args, options, callback) {
   }
 
   var nodePath = process.execPath;
-  var command = shellescape([nodePath, tscPath]);
+  var command = shellescape([tscPath]);
   if (args) {
     command += ' ' + (Array.isArray(args) ? shellescape(args) : args);
   }

--- a/lib/tsc.js
+++ b/lib/tsc.js
@@ -30,9 +30,9 @@ function exec(args, options, callback) {
     }
   }
 
-  var nodePath = process.execPath;
-  var command = shellescape([tscPath]);
-  if (args) {
+  var exe = /(\.exe|\.cmd)$/i.test(tscPath);
+  var command = shellescape(exe ? [tscPath] : [process.execPath, tscPath]);
+  if (args && args.length > 0) {
     command += ' ' + (Array.isArray(args) ? shellescape(args) : args);
   }
   return child_process.exec(command, options, callback);

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "async": "~0.2.10",
     "through2": "~0.4.1",
     "gulp-util": "~2.2.13",
-    "shell-escape": "0.0.1",
     "xtend": "~2.1.2",
     "which": "~1.0.5",
     "byline": "~4.1.1"

--- a/test/gulp-tsc-spec.js
+++ b/test/gulp-tsc-spec.js
@@ -25,7 +25,7 @@ describe('gulp-tsc', function () {
       var stream = typescript();
       stream.once('data', function (file) {
         file.path.should.match(/\.js$/);
-        file.contents.toString().should.equal('var s = "Hello, world";\nvar n = 10;\n');
+        file.contents.toString().should.match(/var s = "Hello, world";\r?\nvar n = 10;/);
 
         fs.existsSync(file.path).should.be.false;
 

--- a/test/tsc-spec.js
+++ b/test/tsc-spec.js
@@ -25,7 +25,7 @@ describe('tsc', function () {
       execStub.calledOnce.should.be.true;
 
       var command = execStub.args[0][0];
-      command.should.match(/^.+?tsc(\.cmd|\.exe)?"? foo bar$/);
+      command.should.match(/^.+?tsc(\.cmd|\.exe)?"? foo bar$/i);
 
       done();
     });
@@ -43,7 +43,7 @@ describe('tsc', function () {
       execStub.calledOnce.should.be.true;
 
       var command = execStub.args[0][0];
-      command.should.match(/^.+?tsc(\.cmd|\.exe)?"? -v$/);
+      command.should.match(/^.+?tsc(\.cmd|\.exe)?"? -v$/i);
 
       done();
     });
@@ -51,7 +51,7 @@ describe('tsc', function () {
   });
 
   it('finds the tsc command location', function () {
-    tsc.find().should.match(/tsc(\.cmd|\.exe)?$/);
+    tsc.find().should.match(/tsc(\.cmd|\.exe)?$/i);
   });
 
 });

--- a/test/tsc-spec.js
+++ b/test/tsc-spec.js
@@ -2,7 +2,7 @@ var helper = require('./helper');
 var tsc = require('../lib/tsc');
 var sinon = require('sinon');
 var child_process = require('child_process');
-var shellescape = require('shell-escape');
+var shellescape = require('../lib/shellescape');
 
 describe('tsc', function () {
   var execStub;
@@ -24,11 +24,8 @@ describe('tsc', function () {
 
       execStub.calledOnce.should.be.true;
 
-      var command = execStub.args[0][0].split(/ +/);
-      command[0].should.equal(shellescape([process.execPath]));
-      command[1].should.match(/tsc$/);
-      command[2].should.equal('foo');
-      command[3].should.equal('bar');
+      var command = execStub.args[0][0];
+      command.should.match(/^.+?tsc(\.cmd|\.exe)?"? foo bar$/);
 
       done();
     });
@@ -45,10 +42,8 @@ describe('tsc', function () {
 
       execStub.calledOnce.should.be.true;
 
-      var command = execStub.args[0][0].split(/ +/);
-      command[0].should.equal(shellescape([process.execPath]));
-      command[1].should.match(/tsc$/);
-      command[2].should.equal('-v');
+      var command = execStub.args[0][0];
+      command.should.match(/^.+?tsc(\.cmd|\.exe)?"? -v$/);
 
       done();
     });
@@ -56,7 +51,7 @@ describe('tsc', function () {
   });
 
   it('finds the tsc command location', function () {
-    tsc.find().should.match(/tsc$/);
+    tsc.find().should.match(/tsc(\.cmd|\.exe)?$/);
   });
 
 });


### PR DESCRIPTION
The problem seems that `shell-escape` module does't work properly for Windows path that contains whitespace.

So replaced `shell-escape` module with original implementation.

Also, some specs didn't go through on Windows due to LFCR, this fixes it as well.
