### PR TITLE
Change the strategy for handling output files

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,11 +69,27 @@ Default: `null`
 
 `--out` option for `tsc` command.
 
+#### options.outDir
+Type: `String`
+Default: `null`
+
+A path to the directory where output files are finally going to.
+
+This option does not affect the actual output directory for `tsc` command.
+
+See `options.sourcemap` for usage of this option.
+
 #### options.mapRoot
 Type: `String`
 Default: `null`
 
 `--mapRoot` option for `tsc` command.
+
+#### options.sourceRoot
+Type: `String`
+Default: `null`
+
+`--sourceRoot` option for `tsc` command.
 
 #### options.allowbool
 Type: `Boolean`
@@ -93,7 +109,7 @@ Default: `false`
 
 `--declaration` option for `tsc` command.
 
-Note: Generated `.d.ts` file is also piped into the stream.
+Generated `.d.ts` file is also piped into the stream.
 
 #### options.noImplicitAny
 Type: `Boolean`
@@ -119,7 +135,37 @@ Default: `false`
 
 `--sourcemap` option for `tsc` command.
 
-Note: Generated `.js.map` file is also piped into the stream.
+Generated `.js.map` file is also piped into the stream.
+
+**Notice**: If your output files are NOT going to `{working directory}/something/` (to a directory beneath the working directory), you have to tell your output path to gulp-tsc by `outDir` option or `sourceRoot` option.
+
+If you have a gulp task like this:
+
+```
+gulp.task('compile', function(){
+  gulp.src(['src/**/*.ts'])
+    .pipe(typescript({ sourcemap: true }))
+    .pipe(gulp.dest('foo/bar/'))
+});
+```
+
+Output files are going under `{working directory}/foo/bar/`, but sourcemap files will contain a relative path to source files from `{working directory}/foo/` which is not correct.
+
+To fix the relative path, just specify `outDir` with your `gulp.dest` path.
+
+```
+gulp.task('compile', function(){
+  gulp.src(['src/**/*.ts'])
+    .pipe(typescript({ sourcemap: true, outDir: 'foo/bar/' }))
+    .pipe(gulp.dest('foo/bar/'))
+});
+```
+
+This is because of gulp's mechanism which does not allow gulp plugins to know where the output files are going to be stored finally.
+
+gulp-tsc assumes that your output files go into `{working directory}/something/` so that the relative paths in sourcemap files are based on that path by default.
+
+`sourceRoot` option is an absolute path to the source location, so you can also fix this problem by specifying it instead of `outDir`.
 
 
 [npm-url]: https://npmjs.org/package/gulp-tsc

--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -134,6 +134,9 @@ Compiler.prototype.processOutputFiles = function (callback) {
   if (this.options.sourcemap && this.options.outDir && !this.options.sourceRoot) {
     stream = stream.pipe(this.fixSourcemapPath());
   }
+  if (this.options.outDir) {
+    stream = stream.pipe(this.fixOutputFilePath());
+  }
   stream.on('data', function (file) {
     _this.emit('data', file);
   });
@@ -157,12 +160,22 @@ Compiler.prototype.fixSourcemapPath = function () {
     var map = JSON.parse(file.contents);
     if (map['sources'] && map['sources'].length > 0) {
       map['sources'] = map['sources'].map(function (sourcePath) {
-        sourcePath = path.resolve(tempDest, sourcePath);
-        sourcePath = path.relative(outDir, sourcePath);
+        sourcePath = path.resolve(path.dirname(file.path), sourcePath);
+        sourcePath = path.relative(path.dirname(path.resolve(outDir, file.relative)), sourcePath);
         return sourcePath;
       });
       file.contents = new Buffer(JSON.stringify(map));
     }
+    this.push(file);
+    done();
+  });
+};
+
+Compiler.prototype.fixOutputFilePath = function () {
+  var outDir = path.resolve(process.cwd(), this.options.outDir);
+  return through.obj(function (file, encoding, done) {
+    file.path = path.resolve(outDir, file.relative);
+    file.cwd = file.base = outDir;
     this.push(file);
     done();
   });

--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -1,25 +1,32 @@
 'use strict';
 
 var tsc = require('./tsc');
-var fs = require('fs');
 var path = require('path');
 var util = require('util');
 var async = require('async');
 var xtend = require('xtend');
 var byline = require('byline');
+var temp = require('temp');
+var through = require('through2');
+var fsSrc = require('vinyl-fs').src;
 var EventEmitter = require('events').EventEmitter;
 
 module.exports = Compiler;
 
-function Compiler(options) {
+function Compiler(sourceFiles, options) {
   EventEmitter.call(this);
+
+  this.sourceFiles = sourceFiles || [];
+
   this.options = xtend({
     tscPath:           null,
     tscSearch:         null,
     module:            'commonjs',
     target:            'ES3',
     out:               null,
+    outDir:            null,
     mapRoot:           null,
+    sourceRoot:        null,
     allowbool:         false,
     allowimportmodule: false,
     declaration:       false,
@@ -34,17 +41,16 @@ function Compiler(options) {
     search: this.options.tscSearch
   };
 
-  this.sourceFiles = [];
-  this.outputFiles = [];
+  this.tempDestination = null;
 }
 util.inherits(Compiler, EventEmitter);
 
 Compiler.prototype.buildTscArguments = function () {
   var args = [];
-  if (this.options.module)            args.push('--module',  this.options.module.toLowerCase());
-  if (this.options.target)            args.push('--target',  this.options.target.toUpperCase());
-  if (this.options.out)               args.push('--out',     this.options.out);
-  if (this.options.mapRoot)           args.push('--mapRoot', this.options.mapRoot);
+  if (this.options.module)            args.push('--module',     this.options.module.toLowerCase());
+  if (this.options.target)            args.push('--target',     this.options.target.toUpperCase());
+  if (this.options.mapRoot)           args.push('--mapRoot',    this.options.mapRoot);
+  if (this.options.sourceRoot)        args.push('--sourceRoot', this.options.sourceRoot);
   if (this.options.allowbool)         args.push('--allowbool');
   if (this.options.allowimportmodule) args.push('--allowimportmodule');
   if (this.options.declaration)       args.push('--declaration');
@@ -52,80 +58,47 @@ Compiler.prototype.buildTscArguments = function () {
   if (this.options.noResolve)         args.push('--noResolve');
   if (this.options.removeComments)    args.push('--removeComments');
   if (this.options.sourcemap)         args.push('--sourcemap');
+
+  if (this.tempDestination) {
+    args.push('--outDir', this.tempDestination);
+    if (this.options.out) {
+      args.push('--out', path.resolve(this.tempDestination, this.options.out));
+    }
+  } else if (this.options.out) {
+    args.push('--out', this.options.out);
+  }
+
   this.sourceFiles.forEach(function (f) { args.push(f.path); });
   return args;
-};
-
-Compiler.prototype.clear = function () {
-  this.sourceFiles = [];
-  this.outputFiles = [];
 };
 
 Compiler.prototype.getVersion = function (callback) {
   return tsc.version(this.tscOptions, callback);
 };
 
-Compiler.prototype.addSourceFile = function (file, encoding) {
-  this.sourceFiles.push(file);
-
-  if (file.path.match(/\.d\.ts$/)) {
-    return;
-  }
-
-  if (this.options.out) {
-    if (this.outputFiles.length === 0) {
-      var outFile = file.clone();
-      outFile.base = file.cwd;
-      outFile.path = path.resolve(file.cwd, this.options.out);
-      this.addOutputFile(outFile, encoding);
-    }
-  } else {
-    var outFile = file.clone();
-    outFile.path = outFile.path.replace(/(\.[^.]+)?$/, '.js');
-    this.addOutputFile(outFile, encoding);
-  }
-};
-
-Compiler.prototype.addOutputFile = function (file, encoding) {
-  var paths = [file.path];
-  if (this.options.declaration) {
-    paths.push(file.path.replace(/(\.js)?$/, '.d.ts'));
-  }
-  if (this.options.sourcemap) {
-    paths.push(file.path + '.map');
-  }
-
-  var _this = this;
-  paths.forEach(function (p) {
-    var newFile = file.clone();
-    newFile.path = p;
-    newFile.contents = null;
-    newFile._encoding = encoding;
-    _this.outputFiles.push(newFile);
-  });
-};
-
 Compiler.prototype.compile = function (callback) {
   var _this = this;
   this.emit('start');
   async.waterfall([
-    this.markNonexistFiles.bind(this),
+    this.makeTempDestinationDir.bind(this),
     this.runTsc.bind(this)
   ], function (err) {
     _this.processOutputFiles(function (err2) {
+      _this.cleanup();
       _this.emit('end');
       callback(err || err2);
     });
   });
 };
 
-Compiler.prototype.markNonexistFiles = function (callback) {
-  async.each(this.outputFiles, function (file, next) {
-    fs.exists(file.path, function (exists) {
-      file._toRemove = !exists;
-      next();
-    });
-  }, callback);
+Compiler.prototype.makeTempDestinationDir = function (callback) {
+  var _this = this;
+  temp.track();
+  temp.mkdir({ dir: process.cwd(), prefix: 'gulp-tsc-tmp-' }, function (err, dirPath) {
+    if (err) callback(err);
+    _this.tempDestination = dirPath;
+    callback(null);
+  });
 };
 
 Compiler.prototype.runTsc = function (callback) {
@@ -156,22 +129,45 @@ Compiler.prototype.runTsc = function (callback) {
 
 Compiler.prototype.processOutputFiles = function (callback) {
   var _this = this;
-  var newOutputFiles = [];
-  async.each(this.outputFiles, function (file, next) {
-    var options = file._encoding ? { encoding: file._encoding } : {};
-    fs.readFile(file.path, options, function (err, contents) {
-      if (err) return next(err);
-      file.contents = new Buffer(contents, file._encoding);
-      newOutputFiles.push(file);
-
-      if (file._toRemove) {
-        fs.unlink(file.path, next);
-      } else {
-        next();
-      }
-    });
-  }, function (err) {
-    _this.outputFiles = newOutputFiles;
+  var options = { cwd: this.tempDestination, cwdbase: true };
+  var stream = fsSrc('**/*{.js,.js.map,.d.ts}', options);
+  if (this.options.sourcemap && this.options.outDir && !this.options.sourceRoot) {
+    stream = stream.pipe(this.fixSourcemapPath());
+  }
+  stream.on('data', function (file) {
+    _this.emit('data', file);
+  });
+  stream.on('error', function (err) {
     callback(err);
   });
+  stream.on('end', function () {
+    callback();
+  });
+};
+
+Compiler.prototype.fixSourcemapPath = function () {
+  var tempDest = this.tempDestination;
+  var outDir = path.resolve(process.cwd(), this.options.outDir);
+  return through.obj(function (file, encoding, done) {
+    if (!file.isBuffer() || !/\.js\.map/.test(file.path)) {
+      this.push(file);
+      return done();
+    }
+
+    var map = JSON.parse(file.contents);
+    if (map['sources'] && map['sources'].length > 0) {
+      map['sources'] = map['sources'].map(function (sourcePath) {
+        sourcePath = path.resolve(tempDest, sourcePath);
+        sourcePath = path.relative(outDir, sourcePath);
+        return sourcePath;
+      });
+      file.contents = new Buffer(JSON.stringify(map));
+    }
+    this.push(file);
+    done();
+  });
+};
+
+Compiler.prototype.cleanup = function () {
+  temp.cleanup();
 };

--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -162,6 +162,7 @@ Compiler.prototype.fixSourcemapPath = function () {
       map['sources'] = map['sources'].map(function (sourcePath) {
         sourcePath = path.resolve(path.dirname(file.path), sourcePath);
         sourcePath = path.relative(path.dirname(path.resolve(outDir, file.relative)), sourcePath);
+        if (path.sep == '\\') sourcePath = sourcePath.replace(/\\/g, '/');
         return sourcePath;
       });
       file.contents = new Buffer(JSON.stringify(map));

--- a/package.json
+++ b/package.json
@@ -30,7 +30,9 @@
     "gulp-util": "~2.2.13",
     "xtend": "~2.1.2",
     "which": "~1.0.5",
-    "byline": "~4.1.1"
+    "byline": "~4.1.1",
+    "temp": "~0.6.0",
+    "vinyl-fs": "0.0.2"
   },
   "devDependencies": {
     "gulp": "~3.5.0",
@@ -39,8 +41,7 @@
     "run-sequence": "~0.3.2",
     "should": "~3.1.2",
     "mocha": "~1.17.1",
-    "sinon": "~1.8.1",
-    "temp": "~0.6.0"
+    "sinon": "~1.8.1"
   },
   "optionalDependencies": {
     "typescript": "~0.9.5"

--- a/test-e2e/.gitignore
+++ b/test-e2e/.gitignore
@@ -1,1 +1,2 @@
 build
+src-inplace/**/*.js

--- a/test-e2e/gulpfile.js
+++ b/test-e2e/gulpfile.js
@@ -119,6 +119,7 @@ gulp.task('test10', ['clean'], function () {
     .pipe(expect([
       'build/test10/proj-a/main.js',
       'build/test10/proj-b/util.js',
+      'build/test10/proj-b/sub/sub.js',
     ]))
 });
 
@@ -139,10 +140,12 @@ gulp.task('test12', ['clean'], function () {
     .pipe(typescript({ sourcemap: true, outDir: 'build/test12' }))
     .pipe(gulp.dest('build/test12'))
     .pipe(expect({
-      'build/test12/proj-a/main.js':     true,
-      'build/test12/proj-a/main.js.map': '"sources":["../../../src-crossproj/proj-a/main.ts"]',
-      'build/test12/proj-b/util.js':     true,
-      'build/test12/proj-b/util.js.map': '"sources":["../../../src-crossproj/proj-b/util.ts"]'
+      'build/test12/proj-a/main.js':        true,
+      'build/test12/proj-a/main.js.map':    '"sources":["../../../src-crossproj/proj-a/main.ts"]',
+      'build/test12/proj-b/util.js':        true,
+      'build/test12/proj-b/util.js.map':    '"sources":["../../../src-crossproj/proj-b/util.ts"]',
+      'build/test12/proj-b/sub/sub.js':     true,
+      'build/test12/proj-b/sub/sub.js.map': '"sources":["../../../../src-crossproj/proj-b/sub/sub.ts"]'
     }))
 });
 
@@ -155,7 +158,7 @@ gulp.task('test13', ['clean'], function () {
       'build/test13/unified.js':     true,
       'build/test13/unified.js.map': [
         '"sourceRoot":"/"',
-        /"sources":\[("(proj-b\/util.ts|proj-a\/main.ts)",?){2}\]/
+        /"sources":\[("(proj-b\/util\.ts|proj-b\/sub\/sub\.ts|proj-a\/main\.ts)",?){3}\]/
       ]
     }))
 });

--- a/test-e2e/gulpfile.js
+++ b/test-e2e/gulpfile.js
@@ -15,7 +15,7 @@ var ignore = function (err) { };
 gulp.task('default', ['all']);
 
 gulp.task('clean', function () {
-  return gulp.src('build', { read: false })
+  return gulp.src('{build,src-inplace/**/*.js}', { read: false })
     .pipe(clean());
 });
 
@@ -158,4 +158,17 @@ gulp.task('test13', ['clean'], function () {
         /"sources":\[("(proj-b\/util.ts|proj-a\/main.ts)",?){2}\]/
       ]
     }))
+});
+
+// Compiling into source directory (in-place)
+gulp.task('test14', ['clean'], function () {
+  return gulp.src('src-inplace/**/*.ts')
+    .pipe(typescript())
+    .pipe(gulp.dest('src-inplace'))
+    .pipe(expect([
+      'src-inplace/top1.js',
+      'src-inplace/top2.js',
+      'src-inplace/sub/sub1.js',
+      'src-inplace/sub/sub2.js',
+    ]))
 });

--- a/test-e2e/gulpfile.js
+++ b/test-e2e/gulpfile.js
@@ -110,3 +110,14 @@ gulp.task('test9', ['clean'], function () {
     .pipe(gulp.dest('build/test9'))
     .pipe(expect([]))
 });
+
+// Compiling cross-project files
+gulp.task('test10', ['clean'], function () {
+  return gulp.src('src-crossproj/proj-a/main.ts')
+    .pipe(typescript()).on('error', abort)
+    .pipe(gulp.dest('build/test10'))
+    .pipe(expect([
+      'build/test10/proj-a/main.js',
+      'build/test10/proj-b/util.js',
+    ]))
+});

--- a/test-e2e/src-crossproj/proj-a/main.ts
+++ b/test-e2e/src-crossproj/proj-a/main.ts
@@ -1,0 +1,2 @@
+/// <reference path="../proj-b/util.ts" />
+console.log(util.upper('abc'));

--- a/test-e2e/src-crossproj/proj-a/main.ts
+++ b/test-e2e/src-crossproj/proj-a/main.ts
@@ -1,2 +1,2 @@
 /// <reference path="../proj-b/util.ts" />
-console.log(util.upper('abc'));
+console.log(util.upper(util.sub.hello));

--- a/test-e2e/src-crossproj/proj-b/sub/sub.ts
+++ b/test-e2e/src-crossproj/proj-b/sub/sub.ts
@@ -1,0 +1,5 @@
+module util {
+	export module sub {
+		export var hello: string = 'hello';
+	}
+}

--- a/test-e2e/src-crossproj/proj-b/util.js
+++ b/test-e2e/src-crossproj/proj-b/util.js
@@ -1,0 +1,7 @@
+var util;
+(function (util) {
+    function upper(s) {
+        return s.toUpperCase();
+    }
+    util.upper = upper;
+})(util || (util = {}));

--- a/test-e2e/src-crossproj/proj-b/util.js
+++ b/test-e2e/src-crossproj/proj-b/util.js
@@ -1,7 +1,0 @@
-var util;
-(function (util) {
-    function upper(s) {
-        return s.toUpperCase();
-    }
-    util.upper = upper;
-})(util || (util = {}));

--- a/test-e2e/src-crossproj/proj-b/util.ts
+++ b/test-e2e/src-crossproj/proj-b/util.ts
@@ -1,0 +1,3 @@
+module util {
+	export function upper(s: string): string { return s.toUpperCase(); }
+}

--- a/test-e2e/src-crossproj/proj-b/util.ts
+++ b/test-e2e/src-crossproj/proj-b/util.ts
@@ -1,3 +1,5 @@
+/// <reference path="./sub/sub.ts" />
+
 module util {
 	export function upper(s: string): string { return s.toUpperCase(); }
 }

--- a/test-e2e/src-inplace/sub/sub1.ts
+++ b/test-e2e/src-inplace/sub/sub1.ts
@@ -1,0 +1,4 @@
+/// <reference path="./sub2.ts" />
+
+console.log("sub1");
+

--- a/test-e2e/src-inplace/sub/sub2.ts
+++ b/test-e2e/src-inplace/sub/sub2.ts
@@ -1,0 +1,1 @@
+console.log("sub2");

--- a/test-e2e/src-inplace/top1.ts
+++ b/test-e2e/src-inplace/top1.ts
@@ -1,0 +1,2 @@
+var s:string = "top1";
+

--- a/test-e2e/src-inplace/top2.ts
+++ b/test-e2e/src-inplace/top2.ts
@@ -1,0 +1,2 @@
+var s:string = "top2";
+

--- a/test/gulp-tsc-spec.js
+++ b/test/gulp-tsc-spec.js
@@ -23,13 +23,15 @@ describe('gulp-tsc', function () {
       fs.closeSync(file.fd);
 
       var stream = typescript();
+      var outputFile;
       stream.once('data', function (file) {
         file.path.should.match(/\.js$/);
         file.contents.toString().should.match(/var s = "Hello, world";\r?\nvar n = 10;/);
-
-        fs.existsSync(file.path).should.be.false;
-
+        outputFile = file;
         done();
+      });
+      stream.on('end', function () {
+        fs.existsSync(outputFile.path).should.be.false;
       });
       stream.write(file);
       stream.end();

--- a/test/helper.js
+++ b/test/helper.js
@@ -10,11 +10,11 @@ module.exports.createDummyProcess = function () {
   proc.stdout = new stream.PassThrough();
   proc.stderr = new stream.PassThrough();
   proc.terminate = function (code) {
-    setTimeout(function () {
+    process.nextTick(function () {
       proc.stdout.end();
       proc.stderr.end();
       proc.emit('exit', code);
-    }, 10);
+    });
   };
   return proc;
 };


### PR DESCRIPTION
By facing issue #6, we should have managed files referenced by compile targets, because they are also compiled implicitly.

This PR changes how we handle output files.

We give --outDir option to tsc with a temporary directory path so that all files generated by tsc command go to the directory, and we can manage them properly. No more "mark and sweep" is needed.

However, this has a side-effect that causes sourcemap files to have unsolvable relative path to the source files.

So we add sourceRoot option and outDir option to manage with this problem. sourceRoot option makes paths in sourcemap files absolute, and outDir option is a hint for Compiler where the output files are going to, so that it can correct paths in sourcemap.
