### PR TITLE
Fix #10: Fix to remove temporary folders with parallel compile

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -7,6 +7,7 @@ var async = require('async');
 var xtend = require('xtend');
 var byline = require('byline');
 var temp = require('temp');
+var rimraf = require('rimraf');
 var through = require('through2');
 var fsSrc = require('vinyl-fs').src;
 var EventEmitter = require('events').EventEmitter;
@@ -183,5 +184,5 @@ Compiler.prototype.fixOutputFilePath = function () {
 };
 
 Compiler.prototype.cleanup = function () {
-  temp.cleanup();
+  rimraf.sync(this.tempDestination);
 };

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "which": "~1.0.5",
     "byline": "~4.1.1",
     "temp": "~0.6.0",
-    "vinyl-fs": "0.0.2"
+    "vinyl-fs": "0.0.2",
+    "rimraf": "~2.2.6"
   },
   "devDependencies": {
     "gulp": "~3.5.0",
@@ -41,7 +42,9 @@
     "run-sequence": "~0.3.2",
     "should": "~3.1.2",
     "mocha": "~1.17.1",
-    "sinon": "~1.8.1"
+    "sinon": "~1.8.1",
+    "event-stream": "~3.1.0",
+    "glob": "~3.2.8"
   },
   "optionalDependencies": {
     "typescript": "~0.9.5"


### PR DESCRIPTION
Fix gulp-tsc sometimes leaves temporary folders behind with compiling
multiple projects in parallel.
