### PR TITLE
Fix fail in parallel compile leave temp folder

### DIFF
--- a/index.js
+++ b/index.js
@@ -47,7 +47,12 @@ module.exports = function (options) {
       if (err) {
         gutil.log(gutil.colors.red('Failed to compile TypeScript:', err));
         if (emitError) {
-          _this.emit('error', new gutil.PluginError('gulp-tsc', 'Failed to compile: ' + (err.message || err)));
+          Compiler.abortAll(function () {
+            _this.emit('error', new gutil.PluginError('gulp-tsc', 'Failed to compile: ' + (err.message || err)));
+            sourceFiles = [];
+            done();
+          });
+          return;
         }
       }
       sourceFiles = [];

--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -79,9 +79,15 @@ Compiler.prototype.getVersion = function (callback) {
 
 Compiler.prototype.compile = function (callback) {
   var _this = this;
+  var checkAborted = this.checkAborted.bind(this);
+
   this.emit('start');
+  Compiler._start(this);
+
   async.waterfall([
+    checkAborted,
     this.makeTempDestinationDir.bind(this),
+    checkAborted,
     this.runTsc.bind(this)
   ], function (err) {
     _this.processOutputFiles(function (err2) {
@@ -92,12 +98,21 @@ Compiler.prototype.compile = function (callback) {
   });
 };
 
+Compiler.prototype.checkAborted = function (callback) {
+  if (Compiler.isAborted()) {
+    callback(new Error('aborted'));
+  } else {
+    callback(null);
+  }
+};
+
 Compiler.prototype.makeTempDestinationDir = function (callback) {
   var _this = this;
   temp.track();
   temp.mkdir({ dir: process.cwd(), prefix: 'gulp-tsc-tmp-' }, function (err, dirPath) {
     if (err) callback(err);
     _this.tempDestination = dirPath;
+
     callback(null);
   });
 };
@@ -184,5 +199,43 @@ Compiler.prototype.fixOutputFilePath = function () {
 };
 
 Compiler.prototype.cleanup = function () {
-  rimraf.sync(this.tempDestination);
+  try {
+    rimraf.sync(this.tempDestination);
+  } catch(e) {}
+};
+
+
+Compiler.running = 0;
+Compiler.aborted = false;
+Compiler.abortCallbacks = [];
+
+Compiler.abortAll = function (callback) {
+  Compiler.aborted = true;
+  callback && Compiler.abortCallbacks.push(callback);
+  if (Compiler.running == 0) {
+    Compiler._allAborted();
+  }
+};
+
+Compiler.isAborted = function () {
+  return Compiler.aborted;
+};
+
+Compiler._start = function (compiler) {
+  Compiler.running++;
+  compiler.once('end', function () {
+    Compiler.running--;
+    if (Compiler.running == 0 && Compiler.aborted) {
+      Compiler._allAborted();
+    }
+  });
+};
+
+Compiler._allAborted = function () {
+  var callbacks = Compiler.abortCallbacks;
+  Compiler.aborted = false;
+  Compiler.abortCallbacks = [];
+  callbacks.forEach(function (fn) {
+    fn.call(null);
+  });
 };

--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -88,7 +88,8 @@ Compiler.prototype.compile = function (callback) {
     checkAborted,
     this.makeTempDestinationDir.bind(this),
     checkAborted,
-    this.runTsc.bind(this)
+    this.runTsc.bind(this),
+    checkAborted
   ], function (err) {
     _this.processOutputFiles(function (err2) {
       _this.cleanup();

--- a/test-e2e/gulpfile.js
+++ b/test-e2e/gulpfile.js
@@ -212,3 +212,24 @@ gulp.task('test16', ['clean'], function () {
       }
     });
 });
+
+// Compile two project in one task with errors
+gulp.task('test17', ['clean'], function () {
+  var one = gulp.src('src-broken/error.ts')
+    .pipe(typescript()).on('error', ignore)
+    .pipe(gulp.dest('build/test17/s1'));
+
+  var two = gulp.src('src/s2/*.ts')
+    .pipe(typescript()).on('error', ignore)
+    .pipe(gulp.dest('build/test17/s2'));
+
+  return es.merge(one, two)
+    .pipe(expect([
+      'build/test17/s2/b.js'
+    ]))
+    .on('end', function () {
+      if (glob.sync('gulp-tsc-tmp-*').length > 0) {
+        throw "Temporary directory is left behind";
+      }
+    });
+});

--- a/test/compiler-spec.js
+++ b/test/compiler-spec.js
@@ -135,4 +135,34 @@ describe('Compiler', function () {
     });
   });
 
+  describe('.abortAll', function () {
+    it('aborts all running compiles', function (done) {
+      this.sinon.stub(tsc, 'exec', function () {
+        throw new Error('should not be here');
+      });
+
+      var compiler1 = new Compiler(), called1 = false;
+      var compiler2 = new Compiler(), called2 = false;
+
+      compiler1.compile(function (err) {
+        err.should.be.an.Error;
+        err.message.should.eql('aborted');
+        called1 = true;
+      });
+      compiler2.compile(function (err) {
+        err.should.be.an.Error;
+        err.message.should.eql('aborted');
+        called2 = true;
+      });
+
+      Compiler.abortAll(function () {
+        process.nextTick(function () {
+          called1.should.be.true;
+          called2.should.be.true;
+          done();
+        });
+      });
+    });
+  });
+
 });


### PR DESCRIPTION
Fixes #10

When failed to compile, uncaught PluginError causes NodeJS to abort everything including cleaning temporary folders.

This commit fixes it by delaying emitting PluginError so that all compilers clean up properly.
