### PR TITLE
Add an option 'tmpDir' to specify where temporary build folders will be in

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,17 @@ gulp.task('tsc', function() {
 
 This will put 'gulp-tsc-tmp-xxxxx' folders in '.tmp'.
 
+
+#### options.noLib
+Type: `Boolean`
+Default: `false`
+
+`--noLib` option for `tsc` command.
+
+Set `noLib` to `true` will dramatically reduce compile time, because 'tsc' will ignore builtin declarations like 'lib.d.ts'.
+So if you are not using 'lib.d.ts' or prefer speed, set this to `true`.
+In my case `noLib:true` only takes 25% time compared to `noLib:false`.
+
 ## Error handling
 
 If gulp-tsc fails to compile files, it emits `error` event with `gutil.PluginError` as the manner of gulp plugins.

--- a/README.md
+++ b/README.md
@@ -175,6 +175,26 @@ gulp-tsc assumes that your output files go into `{working directory}/something/`
 
 `sourceRoot` option is an absolute path to the source location, so you can also fix this problem by specifying it instead of `outDir`.
 
+
+#### options.tmpDir
+Type: `String`
+Default: `''`
+
+A path relative to current working directory, where temporary build folders will be put in.
+If you are watching some files in current working directory with gulp.watch(), the creation of temporary build folder will trigger a folder change event.
+If this is unexpected, you can put temp folders in a non-watched directory with this option.
+
+Example:
+```
+gulp.task('tsc', function() {
+  return gulp.src(src.ts)
+        .pipe(tsc({tmpDir:'.tmp'}))
+        .pipe(gulp.dest('.tmp/js'));
+});
+```
+
+This will put 'gulp-tsc-tmp-xxxxx' folders in '.tmp'.
+
 ## Error handling
 
 If gulp-tsc fails to compile files, it emits `error` event with `gutil.PluginError` as the manner of gulp plugins.

--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -34,7 +34,8 @@ function Compiler(sourceFiles, options) {
     noImplicitAny:     false,
     noResolve:         false,
     removeComments:    false,
-    sourcemap:         false
+    sourcemap:         false,
+    tmpDir:            ''
   }, options);
 
   this.tscOptions = {
@@ -110,7 +111,7 @@ Compiler.prototype.checkAborted = function (callback) {
 Compiler.prototype.makeTempDestinationDir = function (callback) {
   var _this = this;
   temp.track();
-  temp.mkdir({ dir: process.cwd(), prefix: 'gulp-tsc-tmp-' }, function (err, dirPath) {
+  temp.mkdir({ dir: path.resolve(process.cwd(), this.options.tmpDir), prefix: 'gulp-tsc-tmp-' }, function (err, dirPath) {
     if (err) callback(err);
     _this.tempDestination = dirPath;
 

--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -35,7 +35,8 @@ function Compiler(sourceFiles, options) {
     noResolve:         false,
     removeComments:    false,
     sourcemap:         false,
-    tmpDir:            ''
+    tmpDir:            '',
+    noLib:             false
   }, options);
 
   this.tscOptions = {
@@ -60,6 +61,7 @@ Compiler.prototype.buildTscArguments = function () {
   if (this.options.noResolve)         args.push('--noResolve');
   if (this.options.removeComments)    args.push('--removeComments');
   if (this.options.sourcemap)         args.push('--sourcemap');
+  if (this.options.noLib)             args.push('--noLib');
 
   if (this.tempDestination) {
     args.push('--outDir', this.tempDestination);


### PR DESCRIPTION
If I do a gulp.watch() on these files:

```
src.ts   = [
            '*.ts',   // NOTE: some files under current working directory.
            'models/**/*.ts',
            'controllers/**/*.ts'
            ];
```

Then I change a file located at the current working directory like 'app.ts', then the watch will be triggered twice. The first is triggered by 'app.ts', and the second one is by 'gulp-tsc-tmp-xxxx'. I don't know if this is a bug in gulp.watch() (the glob pattern '*.ts' should not include 'gulp-tsc-tmp-xxxx') or normal behavior, it looks complicated to fix.

So I go with a easy way and added an option `tmpDir` to re-locate 'gulp-tsc-tmp-xxxx' folders. May be helpful to someone else who has the same issue.
