### PR TITLE
Use require.resolve() rule when searching for typescript module

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ The path to `tsc` command for compile.
 
 If not set, this plugin searches for `tsc` command in the order as described below:
 
-1. from `(current directory)/node_module/typescript/bin/tsc` (i.e. `typescript` module installed as your project's dependency)
+1. from `typescript` module installed as your project's dependency (i.e. `require("typescript")` on current directory)
 2. from PATH of the running shell (using [node-which](https://github.com/isaacs/node-which))
 3. from Bundled `typescript` module
 

--- a/lib/tsc.js
+++ b/lib/tsc.js
@@ -3,6 +3,7 @@
 var path = require('path');
 var fs = require('fs');
 var child_process = require('child_process');
+var resolve = require('resolve');
 var which = require('which');
 var shellescape = require('./shellescape');
 
@@ -68,8 +69,13 @@ function find(places) {
 
 var searchFunctions = {
   cwd: function () {
-    var tscPath = path.resolve(process.cwd(), './node_modules/typescript/bin/tsc');
-    return fs.existsSync(tscPath) ? tscPath : null;
+    try {
+      var tpath = resolve.sync('typescript', { basedir: process.cwd() });
+      var tscPath = path.resolve(path.dirname(tpath), 'tsc');
+      return fs.existsSync(tscPath) ? tscPath : null;
+    } catch (e) {
+      return null;
+    }
   },
   shell: function () {
     try { return which.sync('tsc') } catch (e) { return null }

--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "byline": "~4.1.1",
     "temp": "~0.7.0",
     "vinyl-fs": "0.0.2",
-    "rimraf": "~2.2.6"
+    "rimraf": "~2.2.6",
+    "resolve": "^0.6.1"
   },
   "devDependencies": {
     "gulp": "~3.5.0",


### PR DESCRIPTION
For #15 

gulp-tsc should follow the [require.resolve() rule of node.js](http://nodejs.org/api/modules.html#modules_loading_from_node_modules_folders) for searching typescript module, so that users can have nested projects with shared node modules.
