### PR TITLE
Fix broken backward compatibility with output file path

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,7 +29,7 @@ module.exports = function (options) {
     });
     compiler.on('error', function (err) {
       gutil.log(gutil.colors.red('[tsc] Error: ' + err.toString()));
-      err.stack && console.log(gutil.color.gray(err.stack));
+      err.stack && console.log(gutil.colors.gray(err.stack));
     });
     compiler.on('data', function (file) {
       _this.push(file);

--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -114,7 +114,7 @@ Compiler.prototype.makeTempDestinationDir = function (callback) {
   var _this = this;
   temp.track();
   temp.mkdir({ dir: path.resolve(process.cwd(), this.options.tmpDir), prefix: 'gulp-tsc-tmp-' }, function (err, dirPath) {
-    if (err) callback(err);
+    if (err) return callback(err);
     _this.tempDestination = dirPath;
 
     callback(null);
@@ -151,11 +151,9 @@ Compiler.prototype.processOutputFiles = function (callback) {
   var _this = this;
   var options = { cwd: this.tempDestination, cwdbase: true };
   var stream = fsSrc('**/*{.js,.js.map,.d.ts}', options);
-  if (this.options.sourcemap && this.options.outDir && !this.options.sourceRoot) {
+  stream = stream.pipe(this.fixOutputFilePath());
+  if (this.options.sourcemap && !this.options.sourceRoot) {
     stream = stream.pipe(this.fixSourcemapPath());
-  }
-  if (this.options.outDir) {
-    stream = stream.pipe(this.fixOutputFilePath());
   }
   stream.on('data', function (file) {
     _this.emit('data', file);
@@ -169,8 +167,6 @@ Compiler.prototype.processOutputFiles = function (callback) {
 };
 
 Compiler.prototype.fixSourcemapPath = function () {
-  var tempDest = this.tempDestination;
-  var outDir = path.resolve(process.cwd(), this.options.outDir);
   return through.obj(function (file, encoding, done) {
     if (!file.isBuffer() || !/\.js\.map/.test(file.path)) {
       this.push(file);
@@ -180,8 +176,8 @@ Compiler.prototype.fixSourcemapPath = function () {
     var map = JSON.parse(file.contents);
     if (map['sources'] && map['sources'].length > 0) {
       map['sources'] = map['sources'].map(function (sourcePath) {
-        sourcePath = path.resolve(path.dirname(file.path), sourcePath);
-        sourcePath = path.relative(path.dirname(path.resolve(outDir, file.relative)), sourcePath);
+        sourcePath = path.resolve(path.dirname(file.originalPath), sourcePath);
+        sourcePath = path.relative(path.dirname(file.path), sourcePath);
         if (path.sep == '\\') sourcePath = sourcePath.replace(/\\/g, '/');
         return sourcePath;
       });
@@ -193,9 +189,24 @@ Compiler.prototype.fixSourcemapPath = function () {
 };
 
 Compiler.prototype.fixOutputFilePath = function () {
-  var outDir = path.resolve(process.cwd(), this.options.outDir);
+  var outDir;
+  if (this.options.outDir) {
+    outDir = path.resolve(process.cwd(), this.options.outDir);
+  } else {
+    outDir = this.tempDestination;
+  }
+
+  if (this.options.out) {
+    var baseDir = '.';
+  } else {
+    // Fix output path by using common part of source files
+    var relatives = this.sourceFiles.map(function (p) { return p.relative });
+    var baseDir = findBaseDirFromPathSet(relatives);
+  }
+
   return through.obj(function (file, encoding, done) {
-    file.path = path.resolve(outDir, file.relative);
+    file.originalPath = file.path;
+    file.path = path.resolve(outDir, baseDir, file.relative);
     file.cwd = file.base = outDir;
     this.push(file);
     done();
@@ -208,6 +219,33 @@ Compiler.prototype.cleanup = function () {
   } catch(e) {}
 };
 
+function findBaseDirFromPathSet(pathSet) {
+  var baseDir = null;
+  for (var i = 0; i < pathSet.length; i++) {
+    var dir = path.dirname(pathSet[i]);
+    if (dir === '.') {
+      baseDir = null;
+      break;
+    }
+    if (!baseDir) {
+      baseDir = dir.split(path.sep);
+      continue;
+    }
+
+    var dirs = dir.split(path.sep);
+    for (var j = 0; j < Math.min(baseDir.length, dirs.length); j++) {
+      if (baseDir[j] !== dirs[j]) {
+        baseDir = baseDir.slice(0, j);
+        break;
+      }
+    }
+    if (baseDir.length === 0) {
+      baseDir = null;
+      break;
+    }
+  }
+  return baseDir ? baseDir.join(path.sep) : '.';
+}
 
 Compiler.running = 0;
 Compiler.aborted = false;

--- a/test-e2e/gulpfile.js
+++ b/test-e2e/gulpfile.js
@@ -233,3 +233,27 @@ gulp.task('test17', ['clean'], function () {
       }
     });
 });
+
+// Compile files in nested directory
+gulp.task('test18', ['clean'], function () {
+  return gulp.src('src-inplace/*/*.ts')
+    .pipe(typescript({ sourcemap: true, outDir: 'build/test18' })).on('error', abort)
+    .pipe(gulp.dest('build/test18'))
+    .pipe(expect({
+      'build/test18/sub/sub1.js':     true,
+      'build/test18/sub/sub1.js.map': '"sources":["../../../src-inplace/sub/sub1.ts"]',
+      'build/test18/sub/sub2.js':     true,
+      'build/test18/sub/sub2.js.map': '"sources":["../../../src-inplace/sub/sub2.ts"]'
+    }))
+});
+
+// Compile files in nested directory into one file
+gulp.task('test19', ['clean'], function () {
+  return gulp.src('src-inplace/*/*.ts')
+    .pipe(typescript({ sourcemap: true, outDir: 'build/test19', out: 'test19.js' })).on('error', abort)
+    .pipe(gulp.dest('build/test19'))
+    .pipe(expect({
+      'build/test19/test19.js':     true,
+      'build/test19/test19.js.map': /"sources":\[("..\/..\/src-inplace\/sub\/sub[12].ts",?){2}\]/
+    }))
+});


### PR DESCRIPTION
For issue #17 

By changing the strategy how to capture output files from tsc in
7156ee45a1e1e3b4a16a7f3189d9405a3db31a74, path of output files changed
accidentally in some cases. This commit fixes it.

When input paths have any common path, tsc skips that common path
and uses only different part of the path for output files.

For example, if we have "foo/bar/a.ts" and "foo/bar/baz/b.ts", tsc skips
"foo/bar/" automatically and outputs "a.ts" and "baz/b.ts". gulp-tsc
followed that rule implicitly by changing the strategy.

However, this is not ideal for gulp tasks since with gulp.src("foo/*_/_.ts")
the plugin should use "bar/a.ts" and "bar/baz/b.ts" for output paths.

To fix this, we add common part of input paths to output paths.
