### PR TITLE
Fix documented default value for options.target

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Default: `"commonjs"`
 
 #### options.target
 Type: `String` (`"ES3"` or `"ES5"`)
-Default: `"ES5"`
+Default: `"ES3"`
 
 `--target` option for `tsc` command.
 


### PR DESCRIPTION
For #19 

The default value should be `ES3`.
