### PR TITLE
Fix incorrect output path when input file refers to other files

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,8 @@ gulp.task('tsc', function() {
 
 This will put a temporary folder in '.tmp'.
 
+See [Temporary directory and file by gulp-tsc](#temporary-directory-and-file-by-gulp-tsc) for details.
+
 #### options.noLib
 Type: `Boolean`
 Default: `false`
@@ -207,6 +209,14 @@ Default: `false`
 Set `noLib` to `true` will dramatically reduce compile time, because 'tsc' will ignore builtin declarations like 'lib.d.ts'.
 
 So if you are not using 'lib.d.ts' or prefer speed, set this to `true`. (In my case `noLib:true` only takes 25% time compared to `noLib:false`)
+
+#### options.keepTree
+Type: `Boolean`
+Default: `true`
+
+If set to false, gulp-tsc skips creating a temporary file in your source directory which is used for keeping source directory structure in output.
+
+See [Temporary directory and file by gulp-tsc](#temporary-directory-and-file-by-gulp-tsc) for details.
 
 ## Error handling
 
@@ -229,6 +239,18 @@ gulp.task('compile', function () {
         .pipe(gulp.dest('dest/'));
 });
 ```
+
+## Temporary directory and file by gulp-tsc
+
+Since gulp-tsc uses `tsc` command internally for compiling TypeScript files, compiled JavaScript files require to be written on the file system temporarily.
+
+For those compiled files, gulp-tsc creates a temporary directory named `gulp-tsc-tmp-*` in the current working directory. You can change the location of the temporary directory by [options.tmpDir](#optionstmpdir).
+
+In addition, gulp-tsc also creates a temporary file named `.gulp-tsc-tmp-*.ts` in your source root directory while compiling. The source root is determined by your `gulp.src()`. (e.g. For `gulp.src("src/**/*.ts")`, the source root is `src/`)
+
+This is required for keeping your source directory structure in output since tsc command omits the common part of your output paths.
+
+If you do not need to keep the structure, you can skip creating the temporary file by setting [options.keepTree](#optionskeeptree) to false.
 
 
 [npm-url]: https://npmjs.org/package/gulp-tsc

--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var tsc = require('./tsc');
+var fs = require('fs');
 var path = require('path');
 var util = require('util');
 var async = require('async');
@@ -36,7 +37,8 @@ function Compiler(sourceFiles, options) {
     removeComments:    false,
     sourcemap:         false,
     tmpDir:            '',
-    noLib:             false
+    noLib:             false,
+    keepTree:          true
   }, options);
 
   this.tscOptions = {
@@ -45,6 +47,7 @@ function Compiler(sourceFiles, options) {
   };
 
   this.tempDestination = null;
+  this.treeKeeperFile  = null;
 }
 util.inherits(Compiler, EventEmitter);
 
@@ -73,6 +76,10 @@ Compiler.prototype.buildTscArguments = function () {
   }
 
   this.sourceFiles.forEach(function (f) { args.push(f.path); });
+  if (this.treeKeeperFile) {
+    args.push(this.treeKeeperFile);
+  }
+
   return args;
 };
 
@@ -90,6 +97,8 @@ Compiler.prototype.compile = function (callback) {
   async.waterfall([
     checkAborted,
     this.makeTempDestinationDir.bind(this),
+    checkAborted,
+    this.makeTreeKeeperFile.bind(this),
     checkAborted,
     this.runTsc.bind(this),
     checkAborted
@@ -117,6 +126,31 @@ Compiler.prototype.makeTempDestinationDir = function (callback) {
     if (err) return callback(err);
     _this.tempDestination = dirPath;
 
+    callback(null);
+  });
+};
+
+Compiler.prototype.makeTreeKeeperFile = function (callback) {
+  if (!this.options.keepTree || this.options.out || this.sourceFiles.length === 0) {
+    return callback(null);
+  }
+
+  var _this = this;
+  temp.open({ dir: this.sourceFiles[0].base, prefix: '.gulp-tsc-tmp-', suffix: '.ts' }, function (err, file) {
+    if (err) {
+      return callback(new Error(
+        'Failed to create a temporary file on source directory: ' + (err.message || err) + ', ' +
+        'To skip creating it specify { keepTree: false } to your gulp-tsc.'
+      ));
+    }
+
+    _this.treeKeeperFile = file.path;
+    try {
+      fs.writeSync(file.fd, '// This is a temporary file by gulp-tsc for keeping directory tree.\n');
+      fs.closeSync(file.fd);
+    } catch (e) {
+      return callback(e);
+    }
     callback(null);
   });
 };
@@ -150,7 +184,12 @@ Compiler.prototype.runTsc = function (callback) {
 Compiler.prototype.processOutputFiles = function (callback) {
   var _this = this;
   var options = { cwd: this.tempDestination, cwdbase: true };
-  var stream = fsSrc('**/*{.js,.js.map,.d.ts}', options);
+  var patterns = ['**/*{.js,.js.map,.d.ts}'];
+  if (this.treeKeeperFile) {
+    patterns.push('!**/' + path.basename(this.treeKeeperFile, '.ts') + '.*');
+  }
+
+  var stream = fsSrc(patterns, options);
   stream = stream.pipe(this.fixOutputFilePath());
   if (this.options.sourcemap && !this.options.sourceRoot) {
     stream = stream.pipe(this.fixSourcemapPath());
@@ -196,17 +235,9 @@ Compiler.prototype.fixOutputFilePath = function () {
     outDir = this.tempDestination;
   }
 
-  if (this.options.out) {
-    var baseDir = '.';
-  } else {
-    // Fix output path by using common part of source files
-    var relatives = this.sourceFiles.map(function (p) { return p.relative });
-    var baseDir = findBaseDirFromPathSet(relatives);
-  }
-
   return through.obj(function (file, encoding, done) {
     file.originalPath = file.path;
-    file.path = path.resolve(outDir, baseDir, file.relative);
+    file.path = path.resolve(outDir, file.relative);
     file.cwd = file.base = outDir;
     this.push(file);
     done();
@@ -214,38 +245,9 @@ Compiler.prototype.fixOutputFilePath = function () {
 };
 
 Compiler.prototype.cleanup = function () {
-  try {
-    rimraf.sync(this.tempDestination);
-  } catch(e) {}
+  try { rimraf.sync(this.tempDestination); } catch(e) {}
+  try { fs.unlinkSync(this.treeKeeperFile); } catch(e) {}
 };
-
-function findBaseDirFromPathSet(pathSet) {
-  var baseDir = null;
-  for (var i = 0; i < pathSet.length; i++) {
-    var dir = path.dirname(pathSet[i]);
-    if (dir === '.') {
-      baseDir = null;
-      break;
-    }
-    if (!baseDir) {
-      baseDir = dir.split(path.sep);
-      continue;
-    }
-
-    var dirs = dir.split(path.sep);
-    for (var j = 0; j < Math.min(baseDir.length, dirs.length); j++) {
-      if (baseDir[j] !== dirs[j]) {
-        baseDir = baseDir.slice(0, j);
-        break;
-      }
-    }
-    if (baseDir.length === 0) {
-      baseDir = null;
-      break;
-    }
-  }
-  return baseDir ? baseDir.join(path.sep) : '.';
-}
 
 Compiler.running = 0;
 Compiler.aborted = false;

--- a/test-e2e/gulpfile.js
+++ b/test-e2e/gulpfile.js
@@ -257,3 +257,15 @@ gulp.task('test19', ['clean'], function () {
       'build/test19/test19.js.map': /"sources":\[("..\/..\/src-inplace\/sub\/sub[12].ts",?){2}\]/
     }))
 });
+
+// for https://github.com/kotas/gulp-tsc/issues/21
+gulp.task('test20', ['clean'], function () {
+  return gulp.src('src-crossproj/*-a/*.ts')
+    .pipe(typescript({ outDir: 'build/test20' })).on('error', abort)
+    .pipe(gulp.dest('build/test20'))
+    .pipe(expect([
+      'build/test20/proj-a/main.js',
+      'build/test20/proj-b/util.js',
+      'build/test20/proj-b/sub/sub.js'
+    ]));
+});

--- a/test/compiler-spec.js
+++ b/test/compiler-spec.js
@@ -92,6 +92,7 @@ describe('Compiler', function () {
           if (err) return done(err);
           if (!fileEmitted) return done(new Error('No data event emitted'));
           fs.existsSync(outputFilePath).should.be.false;
+          fs.existsSync(compiler.treeKeeperFile).should.be.false;
           done();
         });
         compiler.on('data', function (file) {


### PR DESCRIPTION
For issue #21 

To keep a source directory structure, we introduce a new temporary file.

The new temporary file is created in the source root directory so that the common path of output files is the source root and tsc never skips any directory in output.

However, creating a temporary file may fail compilation if the running user has no write-permission on the source directory, or it may increase the time of compilation.

So we also add `keepTree` option so that users can skip creating the temporary file.
