### PR TITLE
Add pathFilter option for modifying paths of compiled files

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ However, this plugin could fail to run the future `tsc` because of incompatible 
 Type: `Array` of `String`
 Default: `['cwd', 'shell', 'bundle']`
 
-This options changes how this plugin searches for `tsc` command on your system.
+This option changes how this plugin searches for `tsc` command on your system.
 
 See [options.tscPath](#optionstscpath) for details.
 
@@ -217,6 +217,54 @@ Default: `true`
 If set to false, gulp-tsc skips creating a temporary file in your source directory which is used for keeping source directory structure in output.
 
 See [Temporary directory and file by gulp-tsc](#temporary-directory-and-file-by-gulp-tsc) for details.
+
+#### options.pathFilter
+Type: `Object`, `Function`
+Default: `null`
+
+This option is used for modifying paths of compiled files.
+
+You can pass a Hash-like object which is a mapping of output paths in relative form.
+
+Example:
+```
+gulp.task('compile', function(){
+  gulp.src(['src/**/*.ts'])
+    .pipe(typescript({
+      pathFilter: { 'aaa/bbb': 'xxx/yyy' }
+    }))
+    .pipe(gulp.dest('build/'))
+});
+```
+
+The example above will compile `src/aaa/bbb/ccc.ts` into `build/xxx/yyy/ccc.js`.
+
+You can also pass a function which takes a relative path of compiled files as an argument and returns a modified path.
+
+Example:
+```
+gulp.task('compile', function(){
+  gulp.src(['src/**/*.ts'])
+    .pipe(typescript({
+      pathFilter: function (path) { return path.replace(/^aaa\/bbb/, 'xxx/yyy') }
+    }))
+    .pipe(gulp.dest('build/'))
+});
+```
+
+A path filter function will receive following two arguments:
+
+- `String`: A relative path to a compiled file.
+- `vinyl.File`: A [vinyl.File](https://github.com/wearefractal/vinyl) object of a compiled file.
+
+A path filter function can return `Boolean`, `String`, `vinyl.File` or `undefined`.
+
+| Returned value      | Effect |
+| ------------------- | ------ |
+| `true`, `undefined` | Use the file as-is. |
+| `false`             | Skip the file. (not piped into output gulp stream) |
+| `String`            | Replace the file's path with the returned string. |
+| `vinyl.File`        | Use the returned vinyl.File instead. |
 
 ## Error handling
 

--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -38,7 +38,8 @@ function Compiler(sourceFiles, options) {
     sourcemap:         false,
     tmpDir:            '',
     noLib:             false,
-    keepTree:          true
+    keepTree:          true,
+    pathFilter:        null
   }, options);
 
   this.tscOptions = {
@@ -205,6 +206,65 @@ Compiler.prototype.processOutputFiles = function (callback) {
   });
 };
 
+Compiler.prototype.fixOutputFilePath = function () {
+  var filter = this.options.pathFilter && this.filterOutput.bind(this);
+  var outDir;
+  if (this.options.outDir) {
+    outDir = path.resolve(process.cwd(), this.options.outDir);
+  } else {
+    outDir = this.tempDestination;
+  }
+
+  return through.obj(function (file, encoding, done) {
+    file.originalPath = file.path;
+    file.path = path.resolve(outDir, file.relative);
+    file.cwd = file.base = outDir;
+    if (filter) {
+      try {
+        file = filter(file);
+      } catch (e) {
+        return done(e);
+      }
+    }
+    if (file) this.push(file);
+    done();
+  });
+};
+
+Compiler.prototype.filterOutput = function (file) {
+  if (!this.options.pathFilter) return file;
+
+  var filter = this.options.pathFilter;
+  if (_.isFunction(filter)) {
+    var ret = filter(file.relative, file);
+    if (ret === true || _.isUndefined(ret)) {
+      return file;
+    } else if (ret === false) {
+      return null;
+    } else if (_.isString(ret)) {
+      file.path = path.resolve(file.base, ret);
+      return file;
+    } else if (_.isObject(ret) && ret.path) {
+      return ret;
+    } else {
+      throw new Error('Unknown return value from pathFilter function');
+    }
+  } else if (_.isPlainObject(filter)) {
+    _.forOwn(filter, function (val, key) {
+      if (_.isString(key) && _.isString(val)) {
+        var src = path.normalize(key) + path.sep;
+        if (file.relative.substr(0, src.length) === src) {
+          file.path = path.resolve(file.base, val, file.relative.substr(src.length) || '.');
+          return false;
+        }
+      }
+    });
+    return file;
+  } else {
+    throw new Error('Unknown type for pathFilter');
+  }
+};
+
 Compiler.prototype.fixSourcemapPath = function () {
   return through.obj(function (file, encoding, done) {
     if (!file.isBuffer() || !/\.js\.map/.test(file.path)) {
@@ -222,23 +282,6 @@ Compiler.prototype.fixSourcemapPath = function () {
       });
       file.contents = new Buffer(JSON.stringify(map));
     }
-    this.push(file);
-    done();
-  });
-};
-
-Compiler.prototype.fixOutputFilePath = function () {
-  var outDir;
-  if (this.options.outDir) {
-    outDir = path.resolve(process.cwd(), this.options.outDir);
-  } else {
-    outDir = this.tempDestination;
-  }
-
-  return through.obj(function (file, encoding, done) {
-    file.originalPath = file.path;
-    file.path = path.resolve(outDir, file.relative);
-    file.cwd = file.base = outDir;
     this.push(file);
     done();
   });

--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -4,8 +4,8 @@ var tsc = require('./tsc');
 var fs = require('fs');
 var path = require('path');
 var util = require('util');
+var _ = require('lodash');
 var async = require('async');
-var xtend = require('xtend');
 var byline = require('byline');
 var temp = require('temp');
 var rimraf = require('rimraf');
@@ -20,7 +20,7 @@ function Compiler(sourceFiles, options) {
 
   this.sourceFiles = sourceFiles || [];
 
-  this.options = xtend({
+  this.options = _.extend({
     tscPath:           null,
     tscSearch:         null,
     module:            'commonjs',

--- a/package.json
+++ b/package.json
@@ -31,13 +31,13 @@
     "async": "^0.8.0",
     "through2": "^0.4.1",
     "gulp-util": "^2.2.14",
-    "xtend": "^3.0.0",
     "which": "^1.0.5",
     "byline": "^4.1.1",
     "temp": "^0.7.0",
     "vinyl-fs": "^0.1.0",
     "rimraf": "^2.2.6",
-    "resolve": "^0.6.1"
+    "resolve": "^0.6.1",
+    "lodash": "^2.4.1"
   },
   "devDependencies": {
     "gulp": "^3.5.5",

--- a/test-e2e/gulpfile.js
+++ b/test-e2e/gulpfile.js
@@ -269,3 +269,22 @@ gulp.task('test20', ['clean'], function () {
       'build/test20/proj-b/sub/sub.js'
     ]));
 });
+
+// Compiling files with pathFilter
+gulp.task('test21', ['clean'], function () {
+  return gulp.src('src-crossproj/proj-a/*.ts')
+    .pipe(typescript({
+      sourcemap: true,
+      outDir: 'build/test21',
+      pathFilter: { 'proj-a': 'a/build', 'proj-b': 'b/build' }
+    })).on('error', abort)
+    .pipe(gulp.dest('build/test21'))
+    .pipe(expect({
+      'build/test21/a/build/main.js':        true,
+      'build/test21/a/build/main.js.map':    '"sources":["../../../../src-crossproj/proj-a/main.ts"]',
+      'build/test21/b/build/util.js':        true,
+      'build/test21/b/build/util.js.map':    '"sources":["../../../../src-crossproj/proj-b/util.ts"]',
+      'build/test21/b/build/sub/sub.js':     true,
+      'build/test21/b/build/sub/sub.js.map': '"sources":["../../../../../src-crossproj/proj-b/sub/sub.ts"]'
+    }))
+});

--- a/test/compiler-spec.js
+++ b/test/compiler-spec.js
@@ -179,15 +179,26 @@ describe('Compiler', function () {
     });
 
     it('changes file.relative by mapping object', function () {
-      var file = helper.createDummyFile({
-        path: '/tmp/foo/bar/baz.js',
-        base: '/tmp'
-      });
-      var filter = { 'foo/bar': 'qux' };
-      var compiler = new Compiler([], { pathFilter: filter });
+      var file, expected;
+      if (path.sep === '/') {
+        file = helper.createDummyFile({
+          path: '/tmp/foo/bar/baz.js',
+          base: '/tmp'
+        });
+        expected = '/tmp/qux/baz.js';
+      } else if (path.sep === '\\') {
+        file = helper.createDummyFile({
+          path: 'C:\\tmp\\foo\\bar\\baz.js',
+          base: 'C:\\tmp'
+        });
+        expected = 'C:\\tmp\\qux\\baz.js';
+      } else {
+        return;
+      }
 
+      var compiler = new Compiler([], { pathFilter: { 'foo/bar': 'qux' } });
       var ret = compiler.filterOutput(file);
-      file.path.should.eql('/tmp/qux/baz.js');
+      file.path.should.eql(expected);
     });
   });
 

--- a/test/compiler-spec.js
+++ b/test/compiler-spec.js
@@ -1,6 +1,7 @@
 var helper = require('./helper');
 var Compiler = require('../lib/compiler');
 var tsc = require('../lib/tsc');
+var should = require('should');
 var sinon = require('sinon');
 var File = require('gulp-util').File;
 var fs = require('fs');
@@ -133,6 +134,60 @@ describe('Compiler', function () {
 
         done();
       });
+    });
+  });
+
+  describe('#filterOutput', function () {
+    it('passes files to pathFilter', function () {
+      var filter = this.sinon.spy();
+      var file = helper.createDummyFile();
+      var compiler = new Compiler([], { pathFilter: filter });
+
+      var ret = compiler.filterOutput(file);
+      ret.should.equal(file);
+
+      filter.calledOnce.should.be.true;
+      filter.calledWith(file.relative, file);
+    });
+
+    it('changes file.relative by returned path', function () {
+      var filter = function () { return 'foo.js' };
+      var file = helper.createDummyFile();
+      var compiler = new Compiler([], { pathFilter: filter });
+
+      var ret = compiler.filterOutput(file);
+      ret.should.equal(file);
+      file.relative.should.eql('foo.js');
+    });
+
+    it('returns file as-is when filter returned true', function () {
+      var filter = function () { return true };
+      var file = helper.createDummyFile();
+      var compiler = new Compiler([], { pathFilter: filter });
+
+      var ret = compiler.filterOutput(file);
+      ret.should.equal(file);
+    });
+
+    it('returns null when filter returned false', function () {
+      var filter = function () { return false; };
+      var file = helper.createDummyFile();
+      var compiler = new Compiler([], { pathFilter: filter });
+
+      var ret = compiler.filterOutput(file);
+      should(ret).be.null;
+    });
+
+    it('changes file.relative by mapping object', function () {
+      var file = helper.createDummyFile({
+        path: '/tmp/foo/bar/baz.js',
+        base: '/tmp'
+      });
+      var filter = { 'foo/bar': 'qux' };
+      var compiler = new Compiler([], { pathFilter: filter });
+
+      var ret = compiler.filterOutput(file);
+      file.path.should.eql('/tmp/qux/baz.js');
     });
   });
 

--- a/test/helper.js
+++ b/test/helper.js
@@ -19,6 +19,14 @@ module.exports.createDummyProcess = function () {
   return proc;
 };
 
+module.exports.createDummyFile = function (options) {
+  options = options || {};
+  if (!options.path) options.path = temp.path({ suffix: '.ts' });
+  if (!options.base) options.base = path.dirname(options.path);
+  if (!options.cwd)  options.cwd  = options.base;
+  return new gutil.File(options);
+};
+
 module.exports.createTemporaryFile = function (fixes, callback) {
   temp.track();
   temp.open(fixes, function (err, info) {


### PR DESCRIPTION
As an answer to https://github.com/kotas/gulp-tsc/issues/6#issuecomment-42126888

Sometimes we want to modify the paths of compiled files for complicated project structure as mentioned in the comment above.

`outputFilter` option is a map of output paths or a function which returns modified output path. See README for details.
