### PR TITLE
Automatic fix reference path in output .d.ts files

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ A path to the directory where output files are finally going to.
 
 This option does not affect the actual output directory for `tsc` command.
 
-See [options.sourcemap](#optionssourcemap) for usage of this option.
+See [Path modification](#path-modification) for usage of this option.
 
 #### options.mapRoot
 Type: `String`
@@ -119,6 +119,8 @@ Default: `false`
 
 Generated `.d.ts` file is also piped into the stream.
 
+**Notice**: If your output files are NOT going to `{working directory}/something/` (to a directory beneath the working directory), you have to tell your output path to gulp-tsc by `outDir` option for correct reference paths. See [Path modification](#path-modification) for details.
+
 #### options.noImplicitAny
 Type: `Boolean`
 Default: `false`
@@ -145,35 +147,7 @@ Default: `false`
 
 Generated `.js.map` file is also piped into the stream.
 
-**Notice**: If your output files are NOT going to `{working directory}/something/` (to a directory beneath the working directory), you have to tell your output path to gulp-tsc by `outDir` option or `sourceRoot` option.
-
-If you have a gulp task like this:
-
-```
-gulp.task('compile', function(){
-  gulp.src(['src/**/*.ts'])
-    .pipe(typescript({ sourcemap: true }))
-    .pipe(gulp.dest('foo/bar/'))
-});
-```
-
-Output files are going under `{working directory}/foo/bar/`, but sourcemap files will contain a relative path to source files from `{working directory}/foo/` which is not correct.
-
-To fix the relative path, just specify `outDir` with your `gulp.dest` path.
-
-```
-gulp.task('compile', function(){
-  gulp.src(['src/**/*.ts'])
-    .pipe(typescript({ sourcemap: true, outDir: 'foo/bar/' }))
-    .pipe(gulp.dest('foo/bar/'))
-});
-```
-
-This is because of gulp's mechanism which does not allow gulp plugins to know where the output files are going to be stored finally.
-
-gulp-tsc assumes that your output files go into `{working directory}/something/` so that the relative paths in sourcemap files are based on that path by default.
-
-`sourceRoot` option is an absolute path to the source location, so you can also fix this problem by specifying it instead of `outDir`.
+**Notice**: If your output files are NOT going to `{working directory}/something/` (to a directory beneath the working directory), you have to tell your output path to gulp-tsc by `outDir` option or `sourceRoot` option. See [Path modification](#path-modification) for details.
 
 #### options.tmpDir
 Type: `String`
@@ -293,6 +267,36 @@ gulp.task('compile', function () {
     return gulp.src('src/**/*.ts')
         .pipe(typescript({ emitError: false }))
         .pipe(gulp.dest('dest/'));
+});
+```
+
+## Path modification
+
+gulp-tsc does some modification to output files to correct relative paths in sourcemap files (.js.map) and declaration files (.d.ts).
+
+However, gulp-tsc doesn't know where your output files are going to be stored finally since it is specified by `gulp.dest` and gulp-tsc cannot access to it. So gulp-tsc assumes that your output files go into `{working directory}/something/` by default.
+
+If your output files are not going there, you have to tell your output path to gulp-tsc by `outDir` option.
+
+If you have a gulp task like this:
+
+```
+gulp.task('compile', function(){
+  gulp.src(['src/**/*.ts'])
+    .pipe(typescript({ sourcemap: true, declaration: true }))
+    .pipe(gulp.dest('foo/bar/'))
+});
+```
+
+Output files are going under `{working directory}/foo/bar/`, but sourcemap files and declaration files will contain a relative path to source files from `{working directory}/foo/` which is not correct.
+
+To fix the relative path, just specify `outDir` same as your `gulp.dest` path.
+
+```
+gulp.task('compile', function(){
+  gulp.src(['src/**/*.ts'])
+    .pipe(typescript({ sourcemap: true, declaration: true, outDir: 'foo/bar/' }))
+    .pipe(gulp.dest('foo/bar/'))
 });
 ```
 

--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -204,6 +204,9 @@ Compiler.prototype.processOutputFiles = function (callback) {
   if (this.options.sourcemap && !this.options.sourceRoot) {
     stream = stream.pipe(this.fixSourcemapPath());
   }
+  if (this.options.declaration && this.options.outDir) {
+    stream = stream.pipe(this.fixReferencePath());
+  }
   stream.on('data', function (file) {
     _this.emit('data', file);
   });
@@ -291,6 +294,28 @@ Compiler.prototype.fixSourcemapPath = function () {
       });
       file.contents = new Buffer(JSON.stringify(map));
     }
+    this.push(file);
+    done();
+  });
+};
+
+Compiler.prototype.fixReferencePath = function () {
+  return through.obj(function (file, encoding, done) {
+    if (!file.isBuffer() || !/\.d\.ts/.test(file.path)) {
+      this.push(file);
+      return done();
+    }
+
+    var newContent = file.contents.toString().replace(
+      /(\/\/\/\s*<reference\s*path\s*=\s*)(["'])(.+?)\2/,
+      function (entire, prefix, quote, refPath) {
+        refPath = path.resolve(path.dirname(file.originalPath), refPath);
+        refPath = path.relative(path.dirname(file.path), refPath);
+        if (path.sep == '\\') refPath = refPath.replace(/\\/g, '/');
+        return prefix + quote + refPath + quote;
+      }
+    );
+    file.contents = new Buffer(newContent);
     this.push(file);
     done();
   });

--- a/test-e2e/gulpfile.js
+++ b/test-e2e/gulpfile.js
@@ -317,3 +317,15 @@ gulp.task('test23', ['clean'], function () {
       }
     });
 });
+
+// Compile files reference to declarations in outer directory with correct path
+// for https://github.com/kotas/gulp-tsc/issues/26
+gulp.task('test24', ['clean'], function () {
+  return gulp.src('src-d-outer/**/main.ts')
+    .pipe(typescript({ declaration: true, outDir: 'build/test24' })).on('error', abort)
+    .pipe(gulp.dest('build/test24'))
+    .pipe(expect({
+      'build/test24/src/main.js':    true,
+      'build/test24/src/main.d.ts':  '<reference path="../../../src-d-outer/hello.d.ts" />'
+    }))
+});

--- a/test-e2e/src-d-outer/hello.d.ts
+++ b/test-e2e/src-d-outer/hello.d.ts
@@ -1,0 +1,4 @@
+declare class Hello {
+    constructor(target: string);
+    greet(): string;
+}

--- a/test-e2e/src-d-outer/src/main.ts
+++ b/test-e2e/src-d-outer/src/main.ts
@@ -1,0 +1,5 @@
+/// <reference path="../hello.d.ts" />
+
+export function helloWorld(): Hello {
+    return new Hello("world");
+}


### PR DESCRIPTION
For https://github.com/kotas/gulp-tsc/issues/26

In output .d.ts files, tsc uses a temporary directory as a base for <reference> paths, which is wrong when the output directory does not have the same level as the temporary directory.

To fix this, we introduce an output filter to fix reference paths for output .d.ts files only. Same as fixing sourcemaps, we need `outDir` is specified to know destination paths.
