### PR TITLE
Fixed "too long command line" error (passing arguments via args file)

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -102,6 +102,8 @@ Compiler.prototype.compile = function (callback) {
     checkAborted,
     this.makeTreeKeeperFile.bind(this),
     checkAborted,
+    this.prepareTscArgumentsFile.bind(this),
+    checkAborted,
     this.runTsc.bind(this),
     checkAborted
   ], function (err) {
@@ -165,9 +167,15 @@ Compiler.prototype.makeTreeKeeperFile = function (callback) {
   });
 };
 
+Compiler.prototype.prepareTscArgumentsFile = function(callback) {
+  var tscArguments = this.buildTscArguments();
+  var content = '"' + tscArguments.join('"\n"') + '"';
+  fs.writeFile(this.tempDestination + '/tscArguments', content, callback); 
+};
+
 Compiler.prototype.runTsc = function (callback) {
   var _this = this;
-  var proc = tsc.exec(this.buildTscArguments(), this.tscOptions);
+  var proc = tsc.exec('"@' + this.tempDestination + '/tscArguments"', this.tscOptions);
   var stdout = byline(proc.stdout);
   var stderr = byline(proc.stderr);
 

--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -49,6 +49,7 @@ function Compiler(sourceFiles, options) {
   };
 
   this.tempDestination = null;
+  this.tscArgumentsFile = null;
   this.treeKeeperFile  = null;
 }
 util.inherits(Compiler, EventEmitter);
@@ -170,12 +171,13 @@ Compiler.prototype.makeTreeKeeperFile = function (callback) {
 Compiler.prototype.prepareTscArgumentsFile = function(callback) {
   var tscArguments = this.buildTscArguments();
   var content = '"' + tscArguments.join('"\n"') + '"';
-  fs.writeFile(this.tempDestination + '/tscArguments', content, callback); 
+  this.tscArgumentsFile = path.join(this.tempDestination, 'tscArguments');
+  fs.writeFile(this.tscArgumentsFile, content, callback); 
 };
 
 Compiler.prototype.runTsc = function (callback) {
   var _this = this;
-  var proc = tsc.exec('"@' + this.tempDestination + '/tscArguments"', this.tscOptions);
+  var proc = tsc.exec(['@' + this.tscArgumentsFile], this.tscOptions);
   var stdout = byline(proc.stdout);
   var stderr = byline(proc.stderr);
 

--- a/test/compiler-spec.js
+++ b/test/compiler-spec.js
@@ -45,9 +45,7 @@ describe('Compiler', function () {
         tsc.exec.calledOnce.should.be.true;
         var args = tsc.exec.args[0];
         args[0].should.eql([
-          '--module', 'commonjs',
-          '--target', 'ES3',
-          '--outDir', compiler.tempDestination
+          '@' + compiler.tscArgumentsFile
         ]);
 
         done();


### PR DESCRIPTION
If you try to compile a lot of files, it will raise an error saying that the command line is too long.
I've changed the plugin to write all arguments on a file and pass it to tsc using the @file option.
