### PR TITLE
attempting to pass arguments in via args file

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -70,7 +70,7 @@ Compiler.prototype.buildTscArguments = function () {
   if (this.options.noLib)             args.push('--noLib');
 
   if (this.tempDestination) {
-    args.push('--outDir', this.tempDestination);
+    args.push('--outDir', "\"" + this.tempDestination + "\"");
     if (this.options.out) {
       args.push('--out', path.resolve(this.tempDestination, this.options.out));
     }
@@ -78,9 +78,9 @@ Compiler.prototype.buildTscArguments = function () {
     args.push('--out', this.options.out);
   }
 
-  this.sourceFiles.forEach(function (f) { args.push(f.path); });
+  this.sourceFiles.forEach(function (f) { args.push("\"" + f.path + "\""); });
   if (this.treeKeeperFile) {
-    args.push(this.treeKeeperFile);
+    args.push("\"" + this.treeKeeperFile + "\"");
   }
 
   return args;
@@ -193,7 +193,7 @@ Compiler.prototype.makeArgumentsFile = function (callback) {
 
 Compiler.prototype.runTsc = function (callback) {
   var _this = this;
-  var proc = tsc.exec("@" + this.argsFile, this.tscOptions);
+  var proc = tsc.exec("@\"" + this.argsFile + "\"", this.tscOptions);
   var stdout = byline(proc.stdout);
   var stderr = byline(proc.stderr);
 

--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -50,6 +50,7 @@ function Compiler(sourceFiles, options) {
 
   this.tempDestination = null;
   this.treeKeeperFile  = null;
+  this.argsFile = null;
 }
 util.inherits(Compiler, EventEmitter);
 
@@ -101,6 +102,8 @@ Compiler.prototype.compile = function (callback) {
     this.makeTempDestinationDir.bind(this),
     checkAborted,
     this.makeTreeKeeperFile.bind(this),
+    checkAborted,
+    this.makeArgumentsFile.bind(this),
     checkAborted,
     this.runTsc.bind(this),
     checkAborted
@@ -165,9 +168,32 @@ Compiler.prototype.makeTreeKeeperFile = function (callback) {
   });
 };
 
+Compiler.prototype.makeArgumentsFile = function (callback) {
+
+    var _this = this;
+
+    temp.open({ dir: this.sourceFiles[0].base, prefix: '.gulp-tsc-tmp-args-', suffix: '.ts' }, function (err, file) {
+        if (err) {
+            return callback(new Error(
+              'Failed to create a temporary file for tsc arguments: ' + (err.message || err)
+            ));
+        }
+
+        _this.argsFile = file.path;
+
+        try {
+            fs.writeSync(file.fd, _this.buildTscArguments().join("\n"));
+            fs.closeSync(file.fd);
+        } catch (e) {
+            return callback(e);
+        }
+        callback(null);
+    });
+};
+
 Compiler.prototype.runTsc = function (callback) {
   var _this = this;
-  var proc = tsc.exec(this.buildTscArguments(), this.tscOptions);
+  var proc = tsc.exec("@" + this.argsFile, this.tscOptions);
   var stdout = byline(proc.stdout);
   var stderr = byline(proc.stderr);
 


### PR DESCRIPTION
instead of passing all the arguments to the command line, they are now written into a temp file that is passed in as the only argument to TSC.  This prevents a situation where the command line is too long and will prevent tsc from erroring out
