### PR TITLE
added global option to fixRegerencePath RegExp

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -307,7 +307,7 @@ Compiler.prototype.fixReferencePath = function () {
     }
 
     var newContent = file.contents.toString().replace(
-      /(\/\/\/\s*<reference\s*path\s*=\s*)(["'])(.+?)\2/,
+      /(\/\/\/\s*<reference\s*path\s*=\s*)(["'])(.+?)\2/g,
       function (entire, prefix, quote, refPath) {
         refPath = path.resolve(path.dirname(file.originalPath), refPath);
         refPath = path.relative(path.dirname(file.path), refPath);


### PR DESCRIPTION
Fixing References are messed up on (d.ts) #40
