### PR TITLE
Update regex to match Version string correctly

### DIFF
--- a/lib/tsc.js
+++ b/lib/tsc.js
@@ -47,7 +47,7 @@ function version(options, callback) {
   return exec('-v', options, function (err, stdout, stderr) {
     if (err) return callback(err, null);
 
-    var version = stdout && stdout.match(/^Version (\d+\.\d+\.\d+\.\d+)/);
+    var version = stdout && stdout.match(/Version (\d+\.\d+\.\d+\.\d+)/);
     version = version && version[1];
 
     callback(null, version);


### PR DESCRIPTION
I've noticed the version string does not get logged correctly after typescript version 1.0.1:

``` bash
[13:24:33] Compiling TypeScript files using tsc version null
```

This is because the output of `tsc -v` now looks like this: 

``` bash
message TS6029: Version 1.1.0.1
```

and the regex matcher is expecting the output to begin with "Version"

This change fixes the regex matcher to correctly match the version.

``` bash
[13:24:54] Compiling TypeScript files using tsc version 1.1.0.1
```
